### PR TITLE
Ignore files of IntelliJ resp. Webstorm

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -10,3 +10,4 @@ temp
 tmp
 TODO.md
 vendor
+.idea


### PR DESCRIPTION
Added support to .gitignore to ignore files in project folders for IntelliJ resp. Webstorm.